### PR TITLE
Add support for .NET Framework 4.7.2 and 4.8

### DIFF
--- a/scripts/products/dotnetfx47.iss
+++ b/scripts/products/dotnetfx47.iss
@@ -1,9 +1,9 @@
-; requires Windows 10, Windows 7 Service Pack 1, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2012, Windows Server 2012 R2, Windows Server 2016
+; requires Windows Server 2016 (version 1709), Windows 10 Anniversary Update (version 1607) (x86 and x64), Windows 10 Creators Update (version 1703) (x86 and x64), Windows 10 Fall Creators Update (version 1709) (x86 and x64), Windows Server 2012 R2 (x64), Windows 8.1 (x86 and x64), Windows Server 2012 (x64), Windows Server 2008 R2 Service Pack 1 (x64), Windows 7 Service Pack 1 (x86 and x64)
 ; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-; https://dotnet.microsoft.com/download/thank-you/net472-offline
+; https://support.microsoft.com/en-us/help/4054531
 
 [CustomMessages]
-dotnetfx47_title=.NET Framework 4.7
+dotnetfx47_title=.NET Framework 4.7.2
 
 dotnetfx47_size=1 MB - 59 MB
 

--- a/scripts/products/dotnetfx48.iss
+++ b/scripts/products/dotnetfx48.iss
@@ -1,6 +1,6 @@
 ; requires Windows 10, Windows 7 Service Pack 1, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2012, Windows Server 2012 R2, Windows Server 2016
 ; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-; https://dotnet.microsoft.com/download/thank-you/net48-offline
+; https://dotnet.microsoft.com/download/dotnet-framework/net48
 
 [CustomMessages]
 dotnetfx48_title=.NET Framework 4.8

--- a/scripts/products/dotnetfx48.iss
+++ b/scripts/products/dotnetfx48.iss
@@ -1,24 +1,24 @@
 ; requires Windows 10, Windows 7 Service Pack 1, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2012, Windows Server 2012 R2, Windows Server 2016
 ; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-; https://dotnet.microsoft.com/download/thank-you/net472-offline
+; https://dotnet.microsoft.com/download/thank-you/net48-offline
 
 [CustomMessages]
-dotnetfx47_title=.NET Framework 4.7
+dotnetfx48_title=.NET Framework 4.8
 
-dotnetfx47_size=1 MB - 59 MB
+dotnetfx48_size=1 MB - 59 MB
 
 [Code]
 const
-	dotnetfx47_url = 'http://download.microsoft.com/download/0/5/C/05C1EC0E-D5EE-463B-BFE3-9311376A6809/NDP472-KB4054531-Web.exe';
+	dotnetfx48_url = 'http://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/c9b8749dd99fc0d4453b2a3e4c37ba16/ndp48-web.exe';
 
-procedure dotnetfx47(minVersion: integer);
+procedure dotnetfx48(minVersion: integer);
 begin
 	if (not netfxinstalled(NetFx4x, '') or (netfxspversion(NetFx4x, '') < minVersion)) then
-		AddProduct('dotnetfx47.exe',
+		AddProduct('dotnetfx48.exe',
 			'/lcid ' + CustomMessage('lcid') + ' /passive /norestart',
-			CustomMessage('dotnetfx47_title'),
-			CustomMessage('dotnetfx47_size'),
-			dotnetfx47_url,
+			CustomMessage('dotnetfx48_title'),
+			CustomMessage('dotnetfx48_size'),
+			dotnetfx48_url,
 			false, false, false);
 end;
 

--- a/scripts/products/dotnetfxversion.iss
+++ b/scripts/products/dotnetfxversion.iss
@@ -72,7 +72,11 @@ begin
 				regVersion := -1;
 		NetFx4x:
 			if (RegQueryDWordValue(HKLM, netfx11plus_reg + 'v4\Full' + lcid, 'Release', regVersion)) then begin
-				if (regVersion >= 461308) then
+        if (regVersion >= 528040) then
+					regVersion := 80 // 4.8+ 
+        else if (regVersion >= 461808) then
+					regVersion := 72 // 4.7.2+
+				else if (regVersion >= 461308) then
 					regVersion := 71 // 4.7.1+
 				else if (regVersion >= 460798) then
 					regVersion := 70 // 4.7+

--- a/scripts/products/dotnetfxversion.iss
+++ b/scripts/products/dotnetfxversion.iss
@@ -72,9 +72,9 @@ begin
 				regVersion := -1;
 		NetFx4x:
 			if (RegQueryDWordValue(HKLM, netfx11plus_reg + 'v4\Full' + lcid, 'Release', regVersion)) then begin
-        if (regVersion >= 528040) then
+				if (regVersion >= 528040) then
 					regVersion := 80 // 4.8+ 
-        else if (regVersion >= 461808) then
+				else if (regVersion >= 461808) then
 					regVersion := 72 // 4.7.2+
 				else if (regVersion >= 461308) then
 					regVersion := 71 // 4.7.1+

--- a/setup.iss
+++ b/setup.iss
@@ -26,6 +26,7 @@
 #define use_dotnetfx45
 #define use_dotnetfx46
 #define use_dotnetfx47
+#define use_dotnetfx48
 
 #define use_msiproduct
 #define use_vc2005
@@ -194,6 +195,10 @@ WindowsServicePack=Windows %1 Service Pack %2
 #include "scripts\products\dotnetfx47.iss"
 #endif
 
+#ifdef use_dotnetfx48
+#include "scripts\products\dotnetfx48.iss"
+#endif
+
 #ifdef use_wic
 #include "scripts\products\wic.iss"
 #endif
@@ -340,6 +345,10 @@ begin
 
 #ifdef use_dotnetfx47
 	dotnetfx47(50); // min allowed version is 4.5.0
+#endif
+
+#ifdef use_dotnetfx48
+	dotnetfx48(72); // min allowed version is 4.7.2
 #endif
 
 #ifdef use_vc2005

--- a/setup.iss
+++ b/setup.iss
@@ -348,7 +348,7 @@ begin
 #endif
 
 #ifdef use_dotnetfx48
-	dotnetfx48(72); // min allowed version is 4.7.2
+	dotnetfx48(50); // min allowed version is 4.5.0
 #endif
 
 #ifdef use_vc2005


### PR DESCRIPTION
Add support for .NET Framework 4.8, as well as 4.7.2. Use the more recent 4.7.2 .NET web installer in dotnetfx47.iss.