### PR TITLE
Add a define to customize the Inno Dependency Installer source folder…

### DIFF
--- a/scripts/isxdl/isxdl.iss
+++ b/scripts/isxdl/isxdl.iss
@@ -1,5 +1,5 @@
 [Files]
-Source: "scripts\isxdl\isxdl.dll"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\isxdl.dll"; Flags: dontcopy noencryption
 
 [Code]
 procedure isxdl_AddFile(URL, Filename: PAnsiChar);

--- a/scripts/lang/chinese.iss
+++ b/scripts/lang/chinese.iss
@@ -15,4 +15,4 @@ chs.depinstall_error=安装依赖组建时出错。请重新启动计算机并�
 chs.isxdl_langfile=chinese.ini
 
 [Files]
-Source: "scripts\isxdl\chinese.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\chinese.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/dutch.iss
+++ b/scripts/lang/dutch.iss
@@ -15,4 +15,4 @@ nl.depinstall_error=Er is een fout opgetreden tijdens het installeren van de afh
 nl.isxdl_langfile=dutch.ini
 
 [Files]
-Source: "scripts\isxdl\dutch.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\dutch.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/french.iss
+++ b/scripts/lang/french.iss
@@ -15,4 +15,4 @@ fr.depinstall_error=Une erreur est survenue lors de l'installation des dépendanc
 fr.isxdl_langfile=french3.ini
 
 [Files]
-Source: "scripts\isxdl\french3.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\french3.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/german.iss
+++ b/scripts/lang/german.iss
@@ -15,4 +15,4 @@ de.depinstall_error=Ein Fehler ist während der Installation der Abghängigkeiten 
 de.isxdl_langfile=german.ini
 
 [Files]
-Source: "scripts\isxdl\german.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\german.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/italian.iss
+++ b/scripts/lang/italian.iss
@@ -15,4 +15,4 @@ it.depinstall_error=Si è verificato un errore durante l'installazione delle dip
 it.isxdl_langfile=italian.ini
 
 [Files]
-Source: "scripts\isxdl\italian.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\italian.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/japanese.iss
+++ b/scripts/lang/japanese.iss
@@ -15,4 +15,4 @@ ja.depinstall_error=依存ファイルのインストール中にエラーが発
 ja.isxdl_langfile=japanese.ini
 
 [Files]
-Source: "scripts\isxdl\japanese.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\japanese.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/polish.iss
+++ b/scripts/lang/polish.iss
@@ -15,4 +15,4 @@ pl.depinstall_error=Wystąpił błąd podczas instalowania zależności. Uruchom
 pl.isxdl_langfile=polish.ini
 
 [Files]
-Source: "scripts\isxdl\polish.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\polish.ini"; Flags: dontcopy noencryption

--- a/scripts/lang/russian.iss
+++ b/scripts/lang/russian.iss
@@ -15,4 +15,4 @@ ru.depinstall_error=В процессе установки зависимост�
 ru.isxdl_langfile=russian.ini
 
 [Files]
-Source: "scripts\isxdl\russian.ini"; Flags: dontcopy noencryption
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\russian.ini"; Flags: dontcopy noencryption

--- a/setup.iss
+++ b/setup.iss
@@ -45,6 +45,8 @@
 #define use_sqlcompact35sp2
 #define use_sql2008express
 
+// Inno Dependency Installer root directory (must be changed when used as a submodule)
+#define InnoDependencyInstallerDir '.'
 
 // supported languages
 #include "scripts\lang\english.iss"


### PR DESCRIPTION
Inno Setup documentation says that the [Source Directory](https://jrsoftware.org/ishelp/index.php?topic=sourcedirectorynotes) works this way:
>By default, the Setup Compiler expects to find files referenced in the script's [Files] section Source parameters, and files referenced in the [Setup] section, under the same directory the script file is located if they do not contain fully qualified pathnames. To specify a different source directory, create a SourceDir directive in the script's [Setup] section.

So using Inno Dependency Installer as a submodule is not possible, because the main script file will be located elsewhere.

This pull request add a "#define InnoDependencyInstallerDir ...." directive to be able to have the Inno Dependency Installer files in a different location than the main ISS file.