### PR TITLE
Use "ShellExec" command instead of "Exec" command, to trigger the UAC…

### DIFF
--- a/scripts/products.pas
+++ b/scripts/products.pas
@@ -69,11 +69,7 @@ function SmartExec(product: TProduct; var resultCode: Integer): Boolean;
 		resultCode: the exit code
 }
 begin
-	if (LowerCase(Copy(product.File, Length(product.File) - 2, 3)) = 'exe') then begin
-		Result := Exec(product.File, product.Parameters, '', SW_SHOWNORMAL, ewWaitUntilTerminated, resultCode);
-	end else begin
-		Result := ShellExec('', product.File, product.Parameters, '', SW_SHOWNORMAL, ewWaitUntilTerminated, resultCode);
-	end;
+	Result := ShellExec('', product.File, product.Parameters, '', SW_SHOWNORMAL, ewWaitUntilTerminated, resultCode);
 end;
 
 function PendingReboot: Boolean;


### PR DESCRIPTION
Use "ShellExec" command instead of "Exec" command, to trigger the UAC privilege elevation prompt when running an EXE installer (for issue  #53)